### PR TITLE
Update to satellite 0.9.2 and Gnome runtime 50

### DIFF
--- a/page.codeberg.tpikonen.satellite.yaml
+++ b/page.codeberg.tpikonen.satellite.yaml
@@ -1,6 +1,6 @@
 app-id: page.codeberg.tpikonen.satellite
 runtime: org.gnome.Platform
-runtime-version: "49"
+runtime-version: "50"
 sdk: org.gnome.Sdk
 command: satellite
 rename-desktop-file: satellite.desktop
@@ -40,9 +40,8 @@ modules:
   - name: satellite
     sources:
       - type: archive
-        url: https://codeberg.org/tpikonen/satellite/archive/0.9.1.tar.gz
-        sha256: 0d0a637acc56d4c404f84e7240c3897e96c34045e1690883abbd2b479b855001
+        url: https://codeberg.org/tpikonen/satellite/archive/0.9.2.tar.gz
+        sha256: 833d8147eb1716232d75a32d5091e71f2af14d29c327714edac7f8cc320a00e4
     buildsystem: simple
     build-commands:
       - pip3 install --verbose --no-index --no-deps --no-build-isolation --prefix=${FLATPAK_DEST} ./
-      - install -Dm644 data/appdata.xml $FLATPAK_DEST/share/metainfo/$FLATPAK_ID.appdata.xml


### PR DESCRIPTION
Remove the appdata install command from build-commands, appdata is now installed by pip.